### PR TITLE
Update metadata.json, compatible with gnome 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
     "41",
     "42",
     "43",
-    "44"
+    "44",
+    "45"
   ],
   "url": "https://github.com/arunk140/gnome-command-menu",
   "uuid": "command-menu@arunk140.com",

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
     "40",
     "41",
     "42",
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/arunk140/gnome-command-menu",
   "uuid": "command-menu@arunk140.com",


### PR DESCRIPTION
Works fine in gnome 44. Thanks for creating this, I use it daily!